### PR TITLE
Add header and footer as they're requited for themes

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,3 @@
+<?php
+
+\Breakdance\Themeless\outputFootHtml();

--- a/header.php
+++ b/header.php
@@ -1,0 +1,3 @@
+<?php
+
+\Breakdance\Themeless\outputHeadHtml();


### PR DESCRIPTION
I deleted them in https://github.com/soflyy/breakdance-zero-theme/pull/2 because we mentioned they may not be needed and it made sense

But I tested some stuff using a child theme and got errors for header and footer missing. It seems they're required. I probably didn't have wp_debug enabled back then so I didn't see the errors.

![image](https://user-images.githubusercontent.com/10674462/186936707-cd79d541-f2d1-435c-892a-b2ba5610801f.png)
