### PR TITLE
Add featured image support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,8 @@ if (!function_exists('breakdance_zero_theme_setup')) {
     function breakdance_zero_theme_setup()
     {
         add_theme_support('title-tag');
+        add_theme_support( 'post-thumbnails' );
+
     }
 }
 


### PR DESCRIPTION
This is working on my local, but not for this user: https://secure.helpscout.net/conversation/2054409205/1228/

Added support for it, tested on the user's site and it worked.

I went through the rest of the supported theme features and I didn't see any we should add. I considered `featured-content`, but I decided against it, I don't think it does anything for us.